### PR TITLE
feat: implement update checking functionality and UI components

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -2,7 +2,10 @@ class AppConstants {
   static const String freediumUrl = 'https://freedium.cfd';
   static const String appName = 'Freedium';
   static const String appDescription = 'Your paywall breakthrough for Medium!';
-  static const String appVersion = '0.4.0';
+  static const String appVersion = String.fromEnvironment(
+    'APP_VERSION',
+    defaultValue: '0.4.0',
+  );
 
   static const String urlRegExp =
       r'^https?:\/\/([\w-]+\.)+[\w-]+(\/[\w-./?%&=@]*)?$';

--- a/lib/core/services/update_service.dart
+++ b/lib/core/services/update_service.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freedium_mobile/core/constants/app_constants.dart';
+import 'package:http/http.dart' as http;
+import 'package:pub_semver/pub_semver.dart';
+
+@immutable
+class UpdateInfo {
+  final String latestVersion;
+  final String releaseUrl;
+  final String releaseNotes;
+
+  const UpdateInfo({
+    required this.latestVersion,
+    required this.releaseUrl,
+    required this.releaseNotes,
+  });
+}
+
+class UpdateService {
+  static const String _repoOwner = 'AmanSikarwar';
+  static const String _repoName = 'freedium_mobile';
+  static const String _apiUrl =
+      'https://api.github.com/repos/$_repoOwner/$_repoName/releases/latest';
+
+  Future<UpdateInfo?> checkForUpdate() async {
+    try {
+      final response = await http.get(Uri.parse(_apiUrl));
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final latestVersionStr = (data['tag_name'] as String).replaceAll(
+          'v',
+          '',
+        );
+        final currentVersionStr = AppConstants.appVersion;
+
+        final latestVersion = Version.parse(latestVersionStr);
+        final currentVersion = Version.parse(currentVersionStr);
+
+        if (latestVersion > currentVersion) {
+          return UpdateInfo(
+            latestVersion: 'v$latestVersionStr',
+            releaseUrl: data['html_url'],
+            releaseNotes: data['body'],
+          );
+        }
+      }
+      return null;
+    } catch (e) {
+      debugPrint('Update check failed: $e');
+      return null;
+    }
+  }
+}
+
+final updateServiceProvider = Provider((ref) => UpdateService());
+
+final updateCheckProvider = FutureProvider<UpdateInfo?>((ref) async {
+  final updateService = ref.watch(updateServiceProvider);
+  return await updateService.checkForUpdate();
+});

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,17 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freedium_mobile/core/constants/app_constants.dart';
+import 'package:freedium_mobile/core/services/update_service.dart';
 import 'package:freedium_mobile/features/home/application/home_provider.dart';
 import 'package:freedium_mobile/features/home/presentation/widgets/about_dialog.dart';
+import 'package:freedium_mobile/features/home/presentation/widgets/update_card.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  bool _isUpdateCardDismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
     final homeState = ref.watch(homeProvider);
     final homeNotifier = ref.read(homeProvider.notifier);
+    final updateAsync = ref.watch(updateCheckProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -42,6 +52,20 @@ class HomeScreen extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
             children: [
+              updateAsync.when(
+                data: (updateInfo) {
+                  if (updateInfo != null && !_isUpdateCardDismissed) {
+                    return UpdateCard(
+                      updateInfo: updateInfo,
+                      onDismissed:
+                          () => setState(() => _isUpdateCardDismissed = true),
+                    );
+                  }
+                  return const SizedBox.shrink();
+                },
+                loading: () => const SizedBox.shrink(),
+                error: (err, stack) => const SizedBox.shrink(),
+              ),
               const Text(
                 AppConstants.appDescription,
                 textAlign: TextAlign.center,

--- a/lib/features/home/presentation/widgets/about_dialog.dart
+++ b/lib/features/home/presentation/widgets/about_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:freedium_mobile/core/constants/app_constants.dart';
+import 'package:freedium_mobile/features/home/presentation/widgets/update_section.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 void showAppAboutDialog(BuildContext context) {
@@ -29,6 +30,7 @@ void showAppAboutDialog(BuildContext context) {
         'Just paste the URL of the article you want to read and '
         'Freedium will take care of the rest!\n\n',
       ),
+      const UpdateSection(),
       Wrap(
         alignment: WrapAlignment.start,
         children: [

--- a/lib/features/home/presentation/widgets/update_card.dart
+++ b/lib/features/home/presentation/widgets/update_card.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:freedium_mobile/core/services/update_service.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class UpdateCard extends StatelessWidget {
+  const UpdateCard({
+    super.key,
+    required this.updateInfo,
+    required this.onDismissed,
+  });
+
+  final UpdateInfo updateInfo;
+  final VoidCallback onDismissed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: const Key('update_card'),
+      onDismissed: (_) => onDismissed(),
+      child: Card(
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Update Available: ${updateInfo.latestVersion}',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.onSecondaryContainer,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                updateInfo.releaseNotes,
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSecondaryContainer,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: onDismissed,
+                    child: const Text('Later'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed:
+                        () => launchUrl(Uri.parse(updateInfo.releaseUrl)),
+                    child: const Text('Update'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/update_section.dart
+++ b/lib/features/home/presentation/widgets/update_section.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freedium_mobile/core/services/update_service.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class UpdateSection extends ConsumerStatefulWidget {
+  const UpdateSection({super.key});
+
+  @override
+  ConsumerState<UpdateSection> createState() => _UpdateSectionState();
+}
+
+class _UpdateSectionState extends ConsumerState<UpdateSection> {
+  bool _isLoading = false;
+  UpdateInfo? _updateInfo;
+  bool _noUpdateAvailable = false;
+
+  Future<void> _checkForUpdate() async {
+    setState(() {
+      _isLoading = true;
+      _noUpdateAvailable = false;
+    });
+
+    final updateService = ref.read(updateServiceProvider);
+    final updateInfo = await updateService.checkForUpdate();
+
+    if (mounted) {
+      setState(() {
+        _isLoading = false;
+        _updateInfo = updateInfo;
+        if (updateInfo == null) {
+          _noUpdateAvailable = true;
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        children: [
+          if (_isLoading)
+            const CircularProgressIndicator()
+          else if (_noUpdateAvailable)
+            const Text('You are using the latest version!')
+          else if (_updateInfo != null)
+            Column(
+              children: [
+                Text('Latest Version: ${_updateInfo!.latestVersion}'),
+                TextButton(
+                  onPressed:
+                      () => launchUrl(Uri.parse(_updateInfo!.releaseUrl)),
+                  child: const Text('View Release Notes'),
+                ),
+              ],
+            )
+          else
+            OutlinedButton.icon(
+              onPressed: _checkForUpdate,
+              icon: const Icon(Icons.update),
+              label: const Text('Check for Updates'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,7 +241,7 @@ packages:
     source: hosted
     version: "6.3.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
@@ -432,6 +432,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  pub_semver:
+    dependency: "direct main"
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   riverpod:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
   flutter_inappwebview: ^6.1.5
   flutter_riverpod: ^2.6.1
   google_fonts: ^6.2.1
+  http: ^1.4.0
   listen_sharing_intent: ^1.9.2
+  pub_semver: ^2.2.0
   share_plus: ^11.0.0
   url_launcher: ^6.3.2
 


### PR DESCRIPTION
This pull request introduces an update-checking feature to the Freedium app, allowing users to be notified of new versions and view release notes directly within the app. It also transitions the `HomeScreen` to a stateful widget to support dismissible update notifications. Below are the most important changes grouped by theme:

### Update-Checking Feature

* Added `UpdateService` class to fetch the latest release information from GitHub, including version, release URL, and notes. Introduced `UpdateInfo` data class to encapsulate update details.
* Created `UpdateCard` widget for displaying update notifications, allowing users to dismiss the card or navigate to the update URL.
* Added `UpdateSection` widget to the app's "About" dialog for manually checking for updates and displaying relevant information.

### Integration into Home Screen

* Modified `HomeScreen` to be a stateful widget, enabling dynamic dismissal of the update card. Integrated the update-checking logic using Riverpod's `FutureProvider`. [[1]](diffhunk://#diff-efed4f50e946c6e317bcdc5e332d4d409ca2b838546bf60cfc7936b003c8413fR4-R24) [[2]](diffhunk://#diff-efed4f50e946c6e317bcdc5e332d4d409ca2b838546bf60cfc7936b003c8413fR55-R68)

### Configuration and Dependencies

* Updated `AppConstants` to dynamically fetch the app version from environment variables, with a default fallback.
* Added `http` and `pub_semver` dependencies to `pubspec.yaml` for API requests and semantic versioning.

These changes collectively enhance the app's functionality by introducing a seamless update-checking mechanism and improving user experience with actionable update notifications.