### PR TITLE
feat: add changelog bottom sheet and update card integration

### DIFF
--- a/lib/features/home/presentation/widgets/changelog_bottom_sheet.dart
+++ b/lib/features/home/presentation/widgets/changelog_bottom_sheet.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:freedium_mobile/core/services/update_service.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class ChangelogBottomSheet extends StatelessWidget {
+  const ChangelogBottomSheet({super.key, required this.updateInfo});
+
+  final UpdateInfo updateInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.5,
+      maxChildSize: 0.9,
+      expand: false,
+      builder: (context, scrollController) {
+        return Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          child: Column(
+            children: [
+              Container(
+                margin: const EdgeInsets.only(top: 12, bottom: 8),
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 8,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'What\'s New',
+                            style: Theme.of(context).textTheme.headlineSmall
+                                ?.copyWith(fontWeight: FontWeight.bold),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Version ${updateInfo.latestVersion}',
+                            style: Theme.of(
+                              context,
+                            ).textTheme.bodyMedium?.copyWith(
+                              color:
+                                  Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.close),
+                      tooltip: 'Close',
+                    ),
+                  ],
+                ),
+              ),
+
+              const Divider(),
+
+              Expanded(
+                child: Markdown(
+                  controller: scrollController,
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  data: updateInfo.releaseNotes,
+                  selectable: true,
+                  styleSheet: MarkdownStyleSheet(
+                    p: TextStyle(
+                      fontSize: 14,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    h1: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    h2: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    h3: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    h4: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    h5: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    h6: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    listBullet: TextStyle(
+                      fontSize: 14,
+                      height: 1.5,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    listIndent: 24,
+                    blockquotePadding: const EdgeInsets.all(12),
+                    blockquoteDecoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      border: Border(
+                        left: BorderSide(
+                          color: theme.colorScheme.primary,
+                          width: 4,
+                        ),
+                      ),
+                    ),
+                    code: TextStyle(
+                      fontSize: 13,
+                      fontFamily: 'monospace',
+                      backgroundColor:
+                          theme.colorScheme.surfaceContainerHighest,
+                    ),
+                    codeblockPadding: const EdgeInsets.all(12),
+                    codeblockDecoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    a: TextStyle(
+                      color: theme.colorScheme.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                  onTapLink: (text, href, title) {
+                    if (href != null) {
+                      launchUrl(Uri.parse(href));
+                    }
+                  },
+                ),
+              ),
+
+              Container(
+                padding: const EdgeInsets.all(24),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  boxShadow: [
+                    BoxShadow(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.shadow.withValues(alpha: 0.1),
+                      blurRadius: 4,
+                      offset: const Offset(0, -2),
+                    ),
+                  ],
+                ),
+                child: SafeArea(
+                  top: false,
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                        launchUrl(Uri.parse(updateInfo.releaseUrl));
+                      },
+                      icon: const Icon(Icons.download),
+                      label: const Text('Update Now'),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+void showChangelogBottomSheet(BuildContext context, UpdateInfo updateInfo) {
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (context) => ChangelogBottomSheet(updateInfo: updateInfo),
+  );
+}

--- a/lib/features/home/presentation/widgets/update_card.dart
+++ b/lib/features/home/presentation/widgets/update_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:freedium_mobile/core/services/update_service.dart';
+import 'package:freedium_mobile/features/home/presentation/widgets/changelog_bottom_sheet.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UpdateCard extends StatelessWidget {
@@ -24,35 +25,74 @@ class UpdateCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                'Update Available: ${updateInfo.latestVersion}',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
-                ),
+              Row(
+                children: [
+                  Icon(
+                    Icons.system_update,
+                    color: Theme.of(context).colorScheme.onSecondaryContainer,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Update Available',
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                            color:
+                                Theme.of(
+                                  context,
+                                ).colorScheme.onSecondaryContainer,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'New version ${updateInfo.latestVersion}',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSecondaryContainer
+                                .withValues(alpha: 0.8),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: 8),
-              Text(
-                updateInfo.releaseNotes,
-                maxLines: 4,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
-                ),
-              ),
-              const SizedBox(height: 12),
+              const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  TextButton(
-                    onPressed: onDismissed,
-                    child: const Text('Later'),
+                  OutlinedButton.icon(
+                    onPressed:
+                        () => showChangelogBottomSheet(context, updateInfo),
+                    icon: const Icon(Icons.article_outlined, size: 18),
+                    label: const Text('View Changelog'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor:
+                          Theme.of(context).colorScheme.onSecondaryContainer,
+                      side: BorderSide(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onSecondaryContainer
+                            .withValues(alpha: 0.5),
+                      ),
+                    ),
                   ),
                   const SizedBox(width: 8),
-                  FilledButton(
+                  FilledButton.icon(
                     onPressed:
                         () => launchUrl(Uri.parse(updateInfo.releaseUrl)),
-                    child: const Text('Update'),
+                    icon: const Icon(Icons.download, size: 18),
+                    label: const Text('Update'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    ),
                   ),
                 ],
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -262,14 +262,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  flutter_md:
-    dependency: "direct main"
-    description:
-      name: flutter_md
-      sha256: b5a67ae49135f7a76a0cc6f938ee3e8754e71d8448b97cf99c11512877f1d055
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.7"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,6 +254,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_markdown_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus
+      sha256: "7f349c075157816da399216a4127096108fd08e1ac931e34e72899281db4113c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_md:
+    dependency: "direct main"
+    description:
+      name: flutter_md
+      sha256: b5a67ae49135f7a76a0cc6f938ee3e8754e71d8448b97cf99c11512877f1d055
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.7"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -400,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_inappwebview: ^6.1.5
+  flutter_markdown_plus: ^1.0.5
+  flutter_md: ^0.0.7
   flutter_riverpod: ^3.0.0
   google_fonts: ^6.3.1
   http: ^1.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   flutter_inappwebview: ^6.1.5
   flutter_markdown_plus: ^1.0.5
-  flutter_md: ^0.0.7
   flutter_riverpod: ^3.0.0
   google_fonts: ^6.3.1
   http: ^1.5.0


### PR DESCRIPTION
This pull request introduces a new changelog bottom sheet for displaying release notes and improves the update notification UI. The main changes include adding a visually rich, interactive changelog modal, updating the `UpdateCard` widget to provide a clearer update prompt and a button to view the changelog, and adding new dependencies for markdown rendering.

**New Changelog Modal:**
* Added `ChangelogBottomSheet` widget in `changelog_bottom_sheet.dart` to display release notes in a scrollable, styled markdown format, with an "Update Now" button that links to the release URL.

**Update Notification UI Improvements:**
* Updated `UpdateCard` to show a more informative update prompt, replaced the "Later" button with a "View Changelog" button that opens the new modal, and enhanced the appearance of the action buttons.

**Integration and Dependency Updates:**
* Imported and integrated the new changelog bottom sheet in `update_card.dart`.
* Added `flutter_markdown_plus` package to `pubspec.yaml` for advanced markdown rendering.