### PR TITLE
refactor: migrate from flutter_inappwebview to webview_flutter

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -107,14 +107,8 @@
               }
 
               function onCopySuccess() {
-                if (
-                  window.flutter_inappwebview &&
-                  window.flutter_inappwebview.callHandler
-                ) {
-                  window.flutter_inappwebview.callHandler(
-                    "Toaster",
-                    "Text copied to clipboard"
-                  );
+                if (window.Toaster && window.Toaster.postMessage) {
+                  window.Toaster.postMessage("Text copied to clipboard");
                 }
               }
 
@@ -221,11 +215,8 @@
       }
 
       try {
-        if (
-          window.flutter_inappwebview &&
-          window.flutter_inappwebview.callHandler
-        ) {
-          window.flutter_inappwebview.callHandler("themeApplied");
+        if (window.themeApplied && window.themeApplied.postMessage) {
+          window.themeApplied.postMessage("done");
         }
       } catch (e) {
         console.warn("Failed to call Flutter handler:", e);
@@ -233,11 +224,8 @@
     } catch (e) {
       console.error("Theme application failed:", e);
       try {
-        if (
-          window.flutter_inappwebview &&
-          window.flutter_inappwebview.callHandler
-        ) {
-          window.flutter_inappwebview.callHandler("themeApplied");
+        if (window.themeApplied && window.themeApplied.postMessage) {
+          window.themeApplied.postMessage("done");
         }
       } catch (handlerError) {
         console.error(

--- a/lib/features/webview/application/webview_provider.dart
+++ b/lib/features/webview/application/webview_provider.dart
@@ -1,11 +1,13 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freedium_mobile/core/constants/app_constants.dart';
 import 'package:freedium_mobile/core/services/font_size_service.dart';
 import 'package:freedium_mobile/features/webview/application/theme_injector_service.dart';
 import 'package:freedium_mobile/features/webview/domain/webview_state.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
 
 class WebviewNotifier extends Notifier<WebviewState> {
   late ThemeInjectorService _themeInjector;
@@ -34,149 +36,124 @@ class WebviewNotifier extends Notifier<WebviewState> {
     _context = context;
   }
 
-  void onWebViewCreated(InAppWebViewController controller) {
-    state = state.copyWith(controller: controller);
-    _addJavaScriptHandlers();
-  }
+  WebViewController createController() {
+    final initialUrl = Uri.parse(AppConstants.freediumUrl).replace(path: url);
 
-  void _addJavaScriptHandlers() {
-    state.controller?.addJavaScriptHandler(
-      handlerName: 'themeApplied',
-      callback: (args) {
-        state = state.copyWith(isThemeApplied: true);
-        _updateInitialLoadState();
-      },
-    );
-
-    state.controller?.addJavaScriptHandler(
-      handlerName: 'Toaster',
-      callback: (args) {
-        if (args.isNotEmpty) {
-          final message = switch (args) {
-            [String text] => text,
-            _ => args.toString(),
-          };
-          if (_context != null) {
+    final controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..addJavaScriptChannel(
+        'themeApplied',
+        onMessageReceived: (JavaScriptMessage message) {
+          state = state.copyWith(isThemeApplied: true);
+          _updateInitialLoadState();
+        },
+      )
+      ..addJavaScriptChannel(
+        'Toaster',
+        onMessageReceived: (JavaScriptMessage message) {
+          if (_context != null && _context!.mounted) {
             ScaffoldMessenger.of(
               _context!,
-            ).showSnackBar(SnackBar(content: Text(message)));
+            ).showSnackBar(SnackBar(content: Text(message.message)));
           }
-        }
-      },
-    );
-  }
+        },
+      )
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onProgress: (int progress) {
+            state = state.copyWith(progress: progress / 100.0);
+          },
+          onPageStarted: (String url) {
+            state = state.copyWith(
+              isThemeApplied: false,
+              isPageLoaded: false,
+              progress: 0,
+              currentUrl: url,
+            );
+          },
+          onPageFinished: (String url) {
+            state = state.copyWith(isPageLoaded: true, currentUrl: url);
+            if (url.startsWith(AppConstants.freediumUrl)) {
+              _injectTheme();
+            } else {
+              state = state.copyWith(isThemeApplied: false);
+            }
+            _updateInitialLoadState();
+          },
+          onWebResourceError: (WebResourceError error) {
+            debugPrint('Error loading page: ${error.description}');
+            state = state.copyWith(
+              isPageLoaded: true,
+              isThemeApplied: false,
+              progress: 1.0,
+            );
+            _updateInitialLoadState();
+          },
+          onNavigationRequest: (NavigationRequest request) async {
+            final uri = Uri.parse(request.url);
 
-  void onLoadStop(InAppWebViewController controller, Uri? url) {
-    state = state.copyWith(isPageLoaded: true);
-    if (url != null && url.toString().startsWith(AppConstants.freediumUrl)) {
-      _injectTheme(controller);
-    } else {
-      state = state.copyWith(isThemeApplied: false);
+            if (!["http", "https"].contains(uri.scheme)) {
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(uri);
+                return NavigationDecision.prevent;
+              }
+            }
+
+            final freediumUri = Uri.parse(AppConstants.freediumUrl);
+            if (uri.host == freediumUri.host) {
+              return NavigationDecision.navigate;
+            }
+
+            try {
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(uri, mode: LaunchMode.externalApplication);
+              }
+            } catch (e) {
+              debugPrint('Failed to launch URL: $e');
+              if (_context != null && _context!.mounted) {
+                ScaffoldMessenger.of(_context!).showSnackBar(
+                  SnackBar(
+                    content: Text('Could not open link: ${uri.toString()}'),
+                  ),
+                );
+              }
+            }
+
+            return NavigationDecision.prevent;
+          },
+        ),
+      )
+      ..loadRequest(initialUrl);
+
+    // Enable debugging in debug mode for Android
+    if (kDebugMode) {
+      if (controller.platform is AndroidWebViewController) {
+        AndroidWebViewController.enableDebugging(true);
+      }
     }
-    _updateInitialLoadState();
+
+    state = state.copyWith(controller: controller);
+    return controller;
   }
 
-  Future<void> _injectTheme(InAppWebViewController controller) async {
-    if (_context == null) return;
+  Future<void> _injectTheme() async {
+    if (_context == null || state.controller == null) return;
     try {
       final script = await _themeInjector.getThemeInjectionScript(
         _context!,
         fontSize: state.fontSize,
       );
-      controller.evaluateJavascript(source: script);
+      state.controller!.runJavaScript(script);
     } catch (e) {
       debugPrint('Failed to inject theme script: $e');
       state = state.copyWith(isThemeApplied: true);
     }
   }
 
-  void onProgressChanged(InAppWebViewController controller, int progress) {
-    state = state.copyWith(progress: progress / 100.0);
-  }
-
-  Future<NavigationActionPolicy> shouldOverrideUrlLoading(
-    InAppWebViewController controller,
-    NavigationAction navigationAction,
-  ) async {
-    state = state.copyWith(
-      isThemeApplied: false,
-      isPageLoaded: false,
-      progress: 0,
-    );
-    var uri = navigationAction.request.url!;
-    if (!["http", "https"].contains(uri.scheme)) {
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri);
-        return NavigationActionPolicy.CANCEL;
-      }
-    }
-
-    final freediumUri = Uri.parse(AppConstants.freediumUrl);
-    if (uri.host == freediumUri.host) {
-      return NavigationActionPolicy.ALLOW;
-    }
-
-    try {
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      }
-    } catch (e) {
-      debugPrint('Failed to launch URL: $e');
-      if (_context != null && _context!.mounted) {
-        ScaffoldMessenger.of(_context!).showSnackBar(
-          SnackBar(content: Text('Could not open link: ${uri.toString()}')),
-        );
-      }
-    }
-
-    return NavigationActionPolicy.CANCEL;
-  }
-
-  void onReceivedError(
-    InAppWebViewController controller,
-    WebResourceRequest request,
-    WebResourceError error,
-  ) {
-    debugPrint('Error loading page: ${error.description}');
-    state = state.copyWith(
-      isPageLoaded: true,
-      isThemeApplied: false,
-      progress: 1.0,
-    );
-    _updateInitialLoadState();
-  }
-
-  void onRenderProcessGone(
-    InAppWebViewController controller,
-    RenderProcessGoneDetail detail,
-  ) {
-    debugPrint('WebView renderer process crashed');
-
-    state = state.copyWith(
-      isPageLoaded: true,
-      isThemeApplied: false,
-      progress: 1.0,
-    );
-    _updateInitialLoadState();
-    ScaffoldMessenger.of(_context!).showSnackBar(
-      SnackBar(
-        content: const Text('WebView renderer process crashed.'),
-        action: SnackBarAction(
-          label: 'Reload',
-          onPressed: () {
-            controller.reload();
-          },
-        ),
-      ),
-    );
-  }
-
   void _updateInitialLoadState() {
     final bool isThemedPage =
-        state.controller?.getUrl().toString().startsWith(
-          AppConstants.freediumUrl,
-        ) ??
-        false;
+        state.currentUrl?.startsWith(AppConstants.freediumUrl) ?? false;
     if (state.isInitialLoad &&
         state.isPageLoaded &&
         (isThemedPage ? state.isThemeApplied : true)) {
@@ -202,7 +179,7 @@ class WebviewNotifier extends Notifier<WebviewState> {
 
     if (state.controller != null && state.isPageLoaded) {
       final script = _themeInjector.getFontSizeUpdateScript(fontSize);
-      state.controller!.evaluateJavascript(source: script);
+      state.controller!.runJavaScript(script);
     }
   }
 }

--- a/lib/features/webview/domain/webview_state.dart
+++ b/lib/features/webview/domain/webview_state.dart
@@ -1,12 +1,13 @@
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class WebviewState {
   final double progress;
   final bool isPageLoaded;
   final bool isThemeApplied;
   final bool isInitialLoad;
-  final InAppWebViewController? controller;
+  final WebViewController? controller;
   final double fontSize;
+  final String? currentUrl;
 
   WebviewState({
     this.progress = 0.0,
@@ -15,6 +16,7 @@ class WebviewState {
     this.isInitialLoad = true,
     this.controller,
     this.fontSize = 18.0,
+    this.currentUrl,
   });
 
   WebviewState copyWith({
@@ -22,8 +24,9 @@ class WebviewState {
     bool? isPageLoaded,
     bool? isThemeApplied,
     bool? isInitialLoad,
-    InAppWebViewController? controller,
+    WebViewController? controller,
     double? fontSize,
+    String? currentUrl,
   }) {
     return WebviewState(
       progress: progress ?? this.progress,
@@ -32,6 +35,7 @@ class WebviewState {
       isInitialLoad: isInitialLoad ?? this.isInitialLoad,
       controller: controller ?? this.controller,
       fontSize: fontSize ?? this.fontSize,
+      currentUrl: currentUrl ?? this.currentUrl,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,70 +174,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_inappwebview:
-    dependency: "direct main"
-    description:
-      name: flutter_inappwebview
-      sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5"
-  flutter_inappwebview_android:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_android
-      sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.3"
-  flutter_inappwebview_internal_annotations:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_internal_annotations
-      sha256: "787171d43f8af67864740b6f04166c13190aa74a1468a1f1f1e9ee5b90c359cd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
-  flutter_inappwebview_ios:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_ios
-      sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
-  flutter_inappwebview_macos:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_macos
-      sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
-  flutter_inappwebview_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_platform_interface
-      sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0+1"
-  flutter_inappwebview_web:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_web
-      sha256: "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
-  flutter_inappwebview_windows:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_windows
-      sha256: "8b4d3a46078a2cdc636c4a3d10d10f2a16882f6be607962dbfff8874d1642055"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -909,6 +845,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_android:
+    dependency: "direct main"
+    description:
+      name: webview_flutter_android
+      sha256: "3fcca88ee2ae568807ebd42deed235bb8dd8e62b3e4d5caff67daa6bce062cca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.9"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: a57b76a081bed3bf3a71a486bdf83642b00f1a7342043d50367cea68f338b1af
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.4"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
   dynamic_color: ^1.8.1
   flutter:
     sdk: flutter
-  flutter_inappwebview: ^6.1.5
+  webview_flutter: ^4.13.0
+  webview_flutter_android: ^4.10.9
   flutter_markdown_plus: ^1.0.5
   flutter_riverpod: ^3.0.3
   google_fonts: ^6.3.2


### PR DESCRIPTION
This pull request migrates the webview implementation from `flutter_inappwebview` to `webview_flutter` and `webview_flutter_android`. The changes refactor the webview provider, state, and presentation code to use the new webview package, update JavaScript communication, and remove legacy code. This improves compatibility and simplifies the integration with Flutter's webview ecosystem.

**Migration to `webview_flutter`:**

* Replaced all usage of `flutter_inappwebview` with `webview_flutter` and `webview_flutter_android` in the provider, state, and screen files (`webview_provider.dart`, `webview_state.dart`, `webview_screen.dart`). [[1]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472R1-R10) [[2]](diffhunk://#diff-d8ca6483108838d791eaea9f8b8676126f84acb66e00e9ccfcd4dab25f22a577L1-R10) [[3]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL1-L3) [[4]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L13-R14)

**Refactoring Webview Provider and State:**

* Updated `WebviewNotifier` to create and manage a `WebViewController`, refactored navigation handling, JavaScript channel setup, and theme injection logic to use the new APIs. [[1]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L37-R105) [[2]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L127-R156) [[3]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L205-R182)
* Modified `WebviewState` to store a `WebViewController` and the current URL, updating the `copyWith` method and usages accordingly. [[1]](diffhunk://#diff-d8ca6483108838d791eaea9f8b8676126f84acb66e00e9ccfcd4dab25f22a577R19-R29) [[2]](diffhunk://#diff-d8ca6483108838d791eaea9f8b8676126f84acb66e00e9ccfcd4dab25f22a577R38)

**Updating Presentation Layer:**

* Refactored `WebviewScreen` to initialize and display the new webview widget, removed legacy pull-to-refresh and event handling, and updated logic to determine when the themed page is loaded. [[1]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL25-R40) [[2]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL62-L67) [[3]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL124-R110) [[4]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL137-R120)

**JavaScript Communication Updates:**

* Changed JavaScript handlers in `theme.js` to use `window.Toaster.postMessage` and `window.themeApplied.postMessage` for communication with Flutter, replacing legacy handler calls. [[1]](diffhunk://#diff-36830fc3e89a6b330e00c7ef30e3001764fa9803c67a9c9fabcacc40578c8df4L110-R111) [[2]](diffhunk://#diff-36830fc3e89a6b330e00c7ef30e3001764fa9803c67a9c9fabcacc40578c8df4L224-R228)

**Minor UI Fixes:**

* Corrected `mainAxisSize` and `MaterialType` usage in the bottom bar for proper rendering. [[1]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL199-R156) [[2]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL244-R197)