### PR TITLE
feat: implement cache clearing functionality in about dialog

### DIFF
--- a/lib/core/services/cache_service.dart
+++ b/lib/core/services/cache_service.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+
+class CacheService {
+  Future<bool> clearWebViewCache() async {
+    try {
+      final controller = WebViewController();
+
+      await controller.clearCache();
+
+      await controller.clearLocalStorage();
+
+      if (controller.platform is AndroidWebViewController) {
+        final androidController =
+            controller.platform as AndroidWebViewController;
+        await androidController.clearCache();
+      }
+
+      debugPrint('WebView cache cleared successfully');
+      return true;
+    } catch (e) {
+      debugPrint('Failed to clear WebView cache: $e');
+      return false;
+    }
+  }
+}
+
+final cacheServiceProvider = Provider((ref) => CacheService());

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -45,7 +45,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
           IconButton(
             icon: const Icon(Icons.info),
-            onPressed: () => showAppAboutDialog(context),
+            onPressed: () => showAppAboutDialog(context, ref),
             tooltip: 'About',
           ),
         ],

--- a/lib/features/home/presentation/widgets/about_dialog.dart
+++ b/lib/features/home/presentation/widgets/about_dialog.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freedium_mobile/core/constants/app_constants.dart';
+import 'package:freedium_mobile/core/services/cache_service.dart';
 import 'package:freedium_mobile/features/home/presentation/widgets/update_section.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-void showAppAboutDialog(BuildContext context) {
+void showAppAboutDialog(BuildContext context, WidgetRef ref) {
   Future<void> launchUri(Uri uri) async {
     try {
       await launchUrl(uri);
@@ -13,6 +15,20 @@ void showAppAboutDialog(BuildContext context) {
           context,
         ).showSnackBar(SnackBar(content: Text('Could not launch URL: $e')));
       }
+    }
+  }
+
+  Future<void> clearCache() async {
+    final cacheService = ref.read(cacheServiceProvider);
+    final success = await cacheService.clearWebViewCache();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            success ? 'Cache cleared successfully' : 'Failed to clear cache',
+          ),
+        ),
+      );
     }
   }
 
@@ -27,6 +43,12 @@ void showAppAboutDialog(BuildContext context) {
         'Just paste the URL of the article you want to read and '
         'Freedium will take care of the rest!\n\n',
       ),
+      OutlinedButton.icon(
+        onPressed: clearCache,
+        icon: const Icon(Icons.delete_outline),
+        label: const Text('Clear Cache'),
+      ),
+      const SizedBox(height: 8),
       const UpdateSection(),
       Wrap(
         children: [


### PR DESCRIPTION
This pull request introduces a new cache clearing feature for the app's WebView and integrates it into the About dialog. The changes include the implementation of a `CacheService`, updates to the About dialog to allow users to clear cache, and necessary adjustments to pass the `WidgetRef` for provider access.

**New Feature: WebView Cache Clearing**
* Added a new `CacheService` class in `lib/core/services/cache_service.dart` that provides a `clearWebViewCache` method to clear both cache and local storage for WebViews, including Android-specific handling.
* Registered `CacheService` as a Riverpod provider (`cacheServiceProvider`) for dependency injection.

**About Dialog Enhancements**
* Updated the `showAppAboutDialog` function in `about_dialog.dart` to accept a `WidgetRef`, enabling provider access for cache clearing.
* Added a `clearCache` function to the About dialog, which calls the cache service and shows a `SnackBar` indicating success or failure.
* Inserted a new "Clear Cache" button in the About dialog UI, allowing users to trigger cache clearing directly from the dialog.

**Integration Updates**
* Modified the About icon button in `home_screen.dart` to pass `ref` when opening the About dialog, ensuring proper provider access.