### PR TITLE
feat: add Freedium URL service and update app constants for mirror URL

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,5 +1,6 @@
 class AppConstants {
   static const String freediumUrl = 'https://freedium.cfd';
+  static const String freediumMirrorUrl = 'https://freedium-mirror.cfd';
   static const String appName = 'Freedium';
   static const String appDescription = 'Your paywall breakthrough for Medium!';
   static const String appVersion = String.fromEnvironment(

--- a/lib/core/services/freedium_url_service.dart
+++ b/lib/core/services/freedium_url_service.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freedium_mobile/core/constants/app_constants.dart';
+
+class FreediumUrlService {
+  String? _cachedWorkingUrl;
+  DateTime? _lastCheckTime;
+
+  static const Duration _cacheDuration = Duration(minutes: 5);
+
+  static const Duration _checkTimeout = Duration(seconds: 5);
+
+  Future<String> getActiveUrl() async {
+    if (_cachedWorkingUrl != null &&
+        _lastCheckTime != null &&
+        DateTime.now().difference(_lastCheckTime!) < _cacheDuration) {
+      return _cachedWorkingUrl!;
+    }
+
+    if (await _isUrlReachable(AppConstants.freediumUrl)) {
+      _cachedWorkingUrl = AppConstants.freediumUrl;
+      _lastCheckTime = DateTime.now();
+      debugPrint('Using primary Freedium URL: ${AppConstants.freediumUrl}');
+      return _cachedWorkingUrl!;
+    }
+
+    if (await _isUrlReachable(AppConstants.freediumMirrorUrl)) {
+      _cachedWorkingUrl = AppConstants.freediumMirrorUrl;
+      _lastCheckTime = DateTime.now();
+      debugPrint(
+        'Using mirror Freedium URL: ${AppConstants.freediumMirrorUrl}',
+      );
+      return _cachedWorkingUrl!;
+    }
+
+    debugPrint('Both Freedium URLs unreachable, defaulting to primary');
+    _cachedWorkingUrl = AppConstants.freediumUrl;
+    _lastCheckTime = DateTime.now();
+    return _cachedWorkingUrl!;
+  }
+
+  Future<bool> _isUrlReachable(String url) async {
+    try {
+      final uri = Uri.parse(url);
+      final client = HttpClient();
+      client.connectionTimeout = _checkTimeout;
+
+      final request = await client.headUrl(uri).timeout(_checkTimeout);
+      final response = await request.close().timeout(_checkTimeout);
+      client.close();
+
+      return response.statusCode >= 200 && response.statusCode < 400;
+    } catch (e) {
+      debugPrint('URL reachability check failed for $url: $e');
+      return false;
+    }
+  }
+
+  void invalidateCache() {
+    _cachedWorkingUrl = null;
+    _lastCheckTime = null;
+  }
+
+  static bool isFreediumUrl(String url) {
+    return url.startsWith(AppConstants.freediumUrl) ||
+        url.startsWith(AppConstants.freediumMirrorUrl);
+  }
+
+  static bool isFreediumHost(String host) {
+    final primaryHost = Uri.parse(AppConstants.freediumUrl).host;
+    final mirrorHost = Uri.parse(AppConstants.freediumMirrorUrl).host;
+    return host == primaryHost || host == mirrorHost;
+  }
+}
+
+final freediumUrlServiceProvider = Provider((ref) => FreediumUrlService());
+
+final activeFreediumUrlProvider = FutureProvider<String>((ref) async {
+  final service = ref.watch(freediumUrlServiceProvider);
+  return service.getActiveUrl();
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,14 +272,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -348,18 +340,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -689,26 +681,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.28.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.14"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: freedium_mobile
 description: "An app to read Medium articles without hitting the paywall"
 publish_to: "none"
-version: 0.6.0
+version: 0.6.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
This pull request introduces a mechanism to dynamically select between the primary Freedium URL and its mirror, improving reliability if the main service is unavailable. The changes add a new service for URL reachability checks, update the webview logic to use the active URL, and refactor references to the Freedium URL throughout the codebase for consistency.

**Dynamic Freedium URL selection and usage:**

* Added `FreediumUrlService` (`lib/core/services/freedium_url_service.dart`) to check which Freedium endpoint is reachable, cache the result, and provide utility methods for identifying Freedium URLs and hosts. Also introduced Riverpod providers for service and active URL.
* Updated `AppConstants` to include the mirror Freedium URL (`freediumMirrorUrl`).

**Webview logic and refactoring:**

* Refactored `WebviewNotifier` (`lib/features/webview/application/webview_provider.dart`) to use the dynamically selected active Freedium URL for initial loads and sharing, and replaced hardcoded checks with service utility methods for determining Freedium URLs and hosts. [[1]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472R5) [[2]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472R18) [[3]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472R28-R29) [[4]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L39-R45) [[5]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L77-R82) [[6]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L103-R108) [[7]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L155-R161)
* Updated `WebviewScreen` (`lib/features/webview/presentation/webview_screen.dart`) to initialize the webview controller with the active Freedium URL and refactored URL checks to use the new service. The share action now uses the active base URL. [[1]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL3-R3) [[2]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL35-R43) [[3]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL109-R115) [[4]](diffhunk://#diff-d454c6e6b2091689a4db2302fe06cf39e7836190ebb979ee9febecda5f7820eeL211-R216)

**Version update:**

* Bumped app version to `0.6.1` in `pubspec.yaml`.