### PR TITLE
V0.11

### DIFF
--- a/lib/core/services/font_size_service.dart
+++ b/lib/core/services/font_size_service.dart
@@ -36,20 +36,21 @@ class FontSizeService {
   }
 
   Future<void> resetFontSize() async {
-    final success = await _prefs.remove(_fontSizeKey);
-    if (!success) {
-      throw Exception('remove returned false for key "$_fontSizeKey"');
-    }
-    final legacySuccess = await _prefs.remove(_legacyDefaultFontSizeKey);
-    if (!legacySuccess) {
-      throw Exception(
-        'remove returned false for key "$_legacyDefaultFontSizeKey"',
-      );
-    }
+    await _removeIfPresent(_fontSizeKey);
+    await _removeIfPresent(_legacyDefaultFontSizeKey);
   }
 
   static double normalizeFontSize(double fontSize) {
     if (!fontSize.isFinite) return defaultFontSize;
     return fontSize.clamp(minFontSize, maxFontSize).toDouble();
+  }
+
+  Future<void> _removeIfPresent(String key) async {
+    if (!_prefs.containsKey(key)) return;
+
+    final success = await _prefs.remove(key);
+    if (!success) {
+      throw Exception('remove returned false for key "$key"');
+    }
   }
 }

--- a/lib/core/services/font_size_service.dart
+++ b/lib/core/services/font_size_service.dart
@@ -9,6 +9,7 @@ final sharedPreferencesProvider = FutureProvider<SharedPreferences>((
 
 class FontSizeService {
   static const String _fontSizeKey = 'webview_font_size';
+  static const String _legacyDefaultFontSizeKey = 'default_font_size';
   static const double minFontSize = 14.0;
   static const double maxFontSize = 28.0;
   static const double defaultFontSize = 18.0;
@@ -27,13 +28,23 @@ class FontSizeService {
   }
 
   double loadFontSize() {
-    return normalizeFontSize(_prefs.getDouble(_fontSizeKey) ?? defaultFontSize);
+    return normalizeFontSize(
+      _prefs.getDouble(_fontSizeKey) ??
+          _prefs.getDouble(_legacyDefaultFontSizeKey) ??
+          defaultFontSize,
+    );
   }
 
   Future<void> resetFontSize() async {
     final success = await _prefs.remove(_fontSizeKey);
     if (!success) {
       throw Exception('remove returned false for key "$_fontSizeKey"');
+    }
+    final legacySuccess = await _prefs.remove(_legacyDefaultFontSizeKey);
+    if (!legacySuccess) {
+      throw Exception(
+        'remove returned false for key "$_legacyDefaultFontSizeKey"',
+      );
     }
   }
 

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freedium_mobile/core/constants/app_constants.dart';
 import 'package:freedium_mobile/core/services/update_service.dart';
 import 'package:freedium_mobile/core/utils/article_url_parser.dart';
+import 'package:freedium_mobile/core/utils/external_url_launcher.dart';
 import 'package:freedium_mobile/features/bookmarks/presentation/bookmarks_screen.dart';
 import 'package:freedium_mobile/features/history/presentation/history_screen.dart';
 import 'package:freedium_mobile/features/home/application/home_provider.dart';
@@ -79,6 +80,21 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     }
 
     _urlController.text = text;
+  }
+
+  Future<void> _launchSourceOnGithub() async {
+    final launched = await ref.read(externalUrlLauncherProvider)(
+      AppConstants.appSourceUrl,
+    );
+    if (!mounted || launched) return;
+
+    HapticFeedback.heavyImpact();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Could not open GitHub'),
+        backgroundColor: Colors.red,
+      ),
+    );
   }
 
   @override
@@ -239,6 +255,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                           },
                           child: const Text('Read Article'),
                         ),
+                      ),
+                      ActionChip(
+                        avatar: const Icon(Icons.star_border, size: 18),
+                        label: const Text('Star on Github'),
+                        onPressed: () {
+                          HapticFeedback.lightImpact();
+                          unawaited(_launchSourceOnGithub());
+                        },
                       ),
                     ],
                   ),

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -258,7 +258,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                       ),
                       ActionChip(
                         avatar: const Icon(Icons.star_border, size: 18),
-                        label: const Text('Star on Github'),
+                        label: const Text('Star on GitHub'),
                         onPressed: () {
                           HapticFeedback.lightImpact();
                           unawaited(_launchSourceOnGithub());

--- a/lib/features/settings/application/settings_service.dart
+++ b/lib/features/settings/application/settings_service.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:freedium_mobile/core/services/font_size_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:freedium_mobile/features/settings/application/mirror_url_normalizer.dart';
 import 'package:freedium_mobile/features/settings/domain/settings_state.dart';
 
 class SettingsService {
   static const String _themeModeKey = 'theme_mode';
-  static const String _defaultFontSizeKey = 'default_font_size';
   static const String _mirrorsKey = 'freedium_mirrors';
   static const String _selectedMirrorUrlKey = 'selected_mirror_url';
   static const String _autoSwitchMirrorKey = 'auto_switch_mirror';
@@ -36,21 +36,11 @@ class SettingsService {
   }
 
   Future<void> saveDefaultFontSize(double fontSize) async {
-    await _savePreference(
-      () => _prefs.setDouble(
-        _defaultFontSizeKey,
-        SettingsState.normalizeDefaultFontSize(fontSize),
-      ),
-      methodName: 'setDouble',
-      key: _defaultFontSizeKey,
-    );
+    await FontSizeService(_prefs).saveFontSize(fontSize);
   }
 
   double loadDefaultFontSize() {
-    return SettingsState.normalizeDefaultFontSize(
-      _prefs.getDouble(_defaultFontSizeKey) ??
-          SettingsState.defaultDefaultFontSize,
-    );
+    return FontSizeService(_prefs).loadFontSize();
   }
 
   Future<void> saveMirrors(List<FreediumMirror> mirrors) async {

--- a/lib/features/webview/application/webview_provider.dart
+++ b/lib/features/webview/application/webview_provider.dart
@@ -40,7 +40,6 @@ WebviewNavigationAction resolveWebviewNavigationAction({
 
 class WebviewNotifier extends Notifier<WebviewState> {
   late ThemeInjectorService _themeInjector;
-  FontSizeService? _fontSizeService;
   late FreediumUrlService _freediumUrlService;
   WebViewController? _controller;
   ColorScheme? _colorScheme;
@@ -58,8 +57,18 @@ class WebviewNotifier extends Notifier<WebviewState> {
 
   @override
   WebviewState build() {
-    final prefsAsync = ref.watch(sharedPreferencesProvider);
     _freediumUrlService = ref.read(freediumUrlServiceProvider);
+
+    ref.listen<double>(
+      settingsProvider.select((settings) => settings.defaultFontSize),
+      (previous, next) {
+        final normalizedFontSize = FontSizeService.normalizeFontSize(next);
+        if (!ref.mounted || state.fontSize == normalizedFontSize) {
+          return;
+        }
+        unawaited(_applyFontSize(normalizedFontSize));
+      },
+    );
 
     ref.onDispose(() {
       final controller = _controller;
@@ -71,33 +80,11 @@ class WebviewNotifier extends Notifier<WebviewState> {
       }
     });
 
-    return prefsAsync.when(
-      data: (prefs) {
-        final service = FontSizeService(prefs);
-        _fontSizeService = service;
-        return WebviewState(fontSize: service.loadFontSize());
-      },
-      loading: WebviewState.new,
-      error: (e, _) {
-        debugPrint('Failed to load SharedPreferences for WebView: $e');
-        return WebviewState();
-      },
+    return WebviewState(
+      fontSize: FontSizeService.normalizeFontSize(
+        ref.read(settingsProvider).defaultFontSize,
+      ),
     );
-  }
-
-  Future<FontSizeService?> _ensureFontSizeService() async {
-    final existingService = _fontSizeService;
-    if (existingService != null) return existingService;
-
-    try {
-      final prefs = await ref.read(sharedPreferencesProvider.future);
-      final service = FontSizeService(prefs);
-      _fontSizeService = service;
-      return service;
-    } catch (e) {
-      debugPrint('FontSizeService unavailable: $e');
-      return null;
-    }
   }
 
   void setThemeInjector(ThemeInjectorService themeInjector) {
@@ -531,23 +518,25 @@ class WebviewNotifier extends Notifier<WebviewState> {
   }
 
   Future<bool> updateFontSize(double fontSize) async {
-    final service = await _ensureFontSizeService();
-    if (service == null) {
-      state = state.copyWith(userMessage: 'Failed to save font size');
-      return false;
-    }
     final normalizedFontSize = FontSizeService.normalizeFontSize(fontSize);
-
-    try {
-      await service.saveFontSize(normalizedFontSize);
-    } catch (e) {
-      debugPrint('Failed to save font size: $e');
+    final didSave = await ref
+        .read(settingsProvider.notifier)
+        .setDefaultFontSize(normalizedFontSize);
+    if (!didSave) {
       state = state.copyWith(userMessage: 'Failed to save font size');
       return false;
     }
 
-    state = state.copyWith(fontSize: normalizedFontSize);
+    if (state.fontSize != normalizedFontSize) {
+      await _applyFontSize(normalizedFontSize);
+    }
 
+    return true;
+  }
+
+  Future<void> _applyFontSize(double fontSize) async {
+    final normalizedFontSize = FontSizeService.normalizeFontSize(fontSize);
+    state = state.copyWith(fontSize: normalizedFontSize);
     final controller = state.controller;
     if (controller != null && state.isPageLoaded) {
       final script = _themeInjector.getFontSizeUpdateScript(normalizedFontSize);
@@ -557,7 +546,6 @@ class WebviewNotifier extends Notifier<WebviewState> {
         debugPrint('Failed to update font size script: $e');
       }
     }
-    return true;
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   cross_file:
     dependency: transitive
     description:
@@ -300,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.2"
   http:
     dependency: "direct main"
     description:
@@ -332,10 +332,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   intl:
     dependency: transitive
     description:
@@ -372,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
+      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.2"
+    version: "1.18.3"
   mime:
     dependency: transitive
     description:
@@ -464,14 +464,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.6"
   node_preamble:
     dependency: transitive
     description:
@@ -484,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
       url: "https://pub.dev"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.1"
   package_config:
     dependency: transitive
     description:
@@ -660,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "67724122431ea01d9318ad1ce08b6ca79f77a38366826f01a45a8ac61b693a01"
+      sha256: a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.24"
+    version: "2.4.25"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -873,10 +865,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.29"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -913,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -937,10 +929,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "47a1b32ee755c3fcffa33db52a7258c137f97bdb2209a1075be847809fac4ccf"
+      sha256: "1d774bbdf6b72a0b12122fc1560c9c2d2a67db5a4a4cc2bd8a5c990ab20e3188"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -1001,10 +993,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: e37e565ed17605a4dbf3ad9c109afb06523e268963e8a9748137e6d8ecd9c955
+      sha256: a97db7a44f8e71af2f3971c45550a08cce1fb60059c1b8e534251e6cfb753490
       url: "https://pub.dev"
     source: hosted
-    version: "4.12.2"
+    version: "4.13.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1017,18 +1009,18 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"
+      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
       url: "https://pub.dev"
     source: hosted
-    version: "3.25.1"
+    version: "3.26.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: ba7d5750e3441caa1bbe31d9e516348fcf8dfcb32aa29ef87a844a59f4d1f1d0
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1041,10 +1033,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   webview_flutter: ^4.13.1
-  webview_flutter_android: ^4.11.0
-  webview_flutter_wkwebview: ^3.0.0
+  webview_flutter_android: ^4.13.0
+  webview_flutter_wkwebview: ^3.26.0
   flutter_markdown_plus: ^1.0.7
   flutter_riverpod: ^3.3.1
   http: ^1.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: freedium_mobile
 description: "An app to read Medium articles without hitting the paywall"
 publish_to: "none"
-version: 0.10.0+10
+version: 0.11.0+11
 
 environment:
   sdk: ^3.12.0

--- a/test/core/services/font_size_service_test.dart
+++ b/test/core/services/font_size_service_test.dart
@@ -1,6 +1,35 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:freedium_mobile/core/services/font_size_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+class _RemoveTrackingSharedPreferencesStore
+    extends SharedPreferencesStorePlatform {
+  _RemoveTrackingSharedPreferencesStore(
+    this.initialValues, {
+    required this.removeResult,
+  });
+
+  final Map<String, Object> initialValues;
+  final bool removeResult;
+  final removeCalls = <String>[];
+
+  @override
+  Future<bool> clear() async => true;
+
+  @override
+  Future<Map<String, Object>> getAll() async => initialValues;
+
+  @override
+  Future<bool> remove(String key) async {
+    removeCalls.add(key);
+    return removeResult;
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async =>
+      true;
+}
 
 void main() {
   group('FontSizeService', () {
@@ -36,5 +65,54 @@ void main() {
         FontSizeService.defaultFontSize,
       );
     });
+
+    test('resetFontSize ignores missing keys before removing', () async {
+      final previousStore = SharedPreferencesStorePlatform.instance;
+      final store = _RemoveTrackingSharedPreferencesStore(
+        {},
+        removeResult: false,
+      );
+      SharedPreferencesStorePlatform.instance = store;
+      SharedPreferences.resetStatic();
+      addTearDown(() {
+        SharedPreferencesStorePlatform.instance = previousStore;
+        SharedPreferences.resetStatic();
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = FontSizeService(prefs);
+
+      await service.resetFontSize();
+
+      expect(store.removeCalls, isEmpty);
+    });
+
+    test(
+      'resetFontSize reports failed removal for existing legacy key',
+      () async {
+        final previousStore = SharedPreferencesStorePlatform.instance;
+        final store = _RemoveTrackingSharedPreferencesStore({
+          'flutter.default_font_size': 22.0,
+        }, removeResult: false);
+        SharedPreferencesStorePlatform.instance = store;
+        SharedPreferences.resetStatic();
+        addTearDown(() {
+          SharedPreferencesStorePlatform.instance = previousStore;
+          SharedPreferences.resetStatic();
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final service = FontSizeService(prefs);
+
+        expect(
+          service.resetFontSize(),
+          throwsA(
+            isA<Exception>().having(
+              (exception) => exception.toString(),
+              'message',
+              contains('default_font_size'),
+            ),
+          ),
+        );
+      },
+    );
   });
 }

--- a/test/core/services/font_size_service_test.dart
+++ b/test/core/services/font_size_service_test.dart
@@ -12,6 +12,14 @@ void main() {
       expect(service.loadFontSize(), FontSizeService.maxFontSize);
     });
 
+    test('loadFontSize falls back to legacy settings key', () async {
+      SharedPreferences.setMockInitialValues({'default_font_size': 22.0});
+      final prefs = await SharedPreferences.getInstance();
+      final service = FontSizeService(prefs);
+
+      expect(service.loadFontSize(), 22.0);
+    });
+
     test('saveFontSize clamps out-of-range values', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();

--- a/test/features/home/presentation/home_screen_test.dart
+++ b/test/features/home/presentation/home_screen_test.dart
@@ -76,7 +76,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Star on Github'));
+      await tester.tap(find.text('Star on GitHub'));
       await tester.pumpAndSettle();
 
       expect(launchedUrls, [AppConstants.appSourceUrl]);

--- a/test/features/home/presentation/home_screen_test.dart
+++ b/test/features/home/presentation/home_screen_test.dart
@@ -3,7 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freedium_mobile/core/constants/app_constants.dart';
 import 'package:freedium_mobile/core/services/clipboard_service.dart';
+import 'package:freedium_mobile/core/utils/external_url_launcher.dart';
 import 'package:freedium_mobile/features/home/presentation/home_screen.dart';
 
 class _FakeClipboardService extends ClipboardService {
@@ -50,6 +52,34 @@ void main() {
 
       expect(find.text('Read Article'), findsOneWidget);
       expect(find.text('Get Article'), findsNothing);
+    });
+
+    testWidgets('opens the source repository from the GitHub star chip', (
+      tester,
+    ) async {
+      final clipboard = _FakeClipboardService(null);
+      final launchedUrls = <String?>[];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            clipboardServiceProvider.overrideWith((ref) => clipboard),
+            externalUrlLauncherProvider.overrideWith((ref) {
+              return (url) async {
+                launchedUrls.add(url);
+                return true;
+              };
+            }),
+          ],
+          child: const MaterialApp(home: HomeScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Star on Github'));
+      await tester.pumpAndSettle();
+
+      expect(launchedUrls, [AppConstants.appSourceUrl]);
     });
 
     testWidgets('auto-fills a valid article URL from the clipboard', (

--- a/test/features/settings/application/settings_provider_test.dart
+++ b/test/features/settings/application/settings_provider_test.dart
@@ -176,7 +176,7 @@ void main() {
       expect(settings.defaultFontSize, SettingsState.maxDefaultFontSize);
       expect(settings.mirrorTimeout, SettingsState.minMirrorTimeout);
       expect(
-        prefs.getDouble('default_font_size'),
+        prefs.getDouble('webview_font_size'),
         SettingsState.maxDefaultFontSize,
       );
       expect(prefs.getInt('mirror_timeout'), SettingsState.minMirrorTimeout);

--- a/test/features/settings/application/settings_service_test.dart
+++ b/test/features/settings/application/settings_service_test.dart
@@ -135,7 +135,7 @@ void main() {
 
     test('loadAllSettings clamps persisted numeric preferences', () async {
       SharedPreferences.setMockInitialValues({
-        'default_font_size': 100.0,
+        'webview_font_size': 100.0,
         'mirror_timeout': 0,
       });
 
@@ -148,6 +148,15 @@ void main() {
       expect(settings.mirrorTimeout, SettingsState.minMirrorTimeout);
     });
 
+    test('loadAllSettings reads legacy default font size key', () async {
+      SharedPreferences.setMockInitialValues({'default_font_size': 22.0});
+
+      final prefs = await SharedPreferences.getInstance();
+      final service = SettingsService(prefs);
+
+      expect(service.loadAllSettings().defaultFontSize, 22.0);
+    });
+
     test('save numeric preferences clamps out-of-range values', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
@@ -157,7 +166,7 @@ void main() {
       await service.saveMirrorTimeout(100);
 
       expect(
-        prefs.getDouble('default_font_size'),
+        prefs.getDouble('webview_font_size'),
         SettingsState.minDefaultFontSize,
       );
       expect(prefs.getInt('mirror_timeout'), SettingsState.maxMirrorTimeout);

--- a/test/features/webview/application/webview_provider_font_size_test.dart
+++ b/test/features/webview/application/webview_provider_font_size_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freedium_mobile/core/services/font_size_service.dart';
+import 'package:freedium_mobile/features/settings/application/settings_provider.dart';
 import 'package:freedium_mobile/features/webview/application/webview_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
@@ -58,7 +59,32 @@ void main() {
       await container.read(provider.notifier).updateFontSize(100);
 
       expect(container.read(provider).fontSize, FontSizeService.maxFontSize);
+      expect(
+        container.read(settingsProvider).defaultFontSize,
+        FontSizeService.maxFontSize,
+      );
       expect(prefs.getDouble('webview_font_size'), FontSizeService.maxFontSize);
+    });
+
+    test('tracks font size changes made from settings', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWith((ref) async => prefs),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final provider = webviewProvider('https://medium.com/example/story');
+      container.read(provider);
+      await container.read(sharedPreferencesProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      await container.read(settingsProvider.notifier).setDefaultFontSize(22);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(provider).fontSize, 22.0);
     });
 
     test('keeps font size and reports message when saving fails', () async {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings centered around font size management, settings integration, and user experience enhancements in the app. The most significant changes include consolidating font size logic, improving legacy key support, simplifying the webview provider's font size handling, and adding a user-facing GitHub star action. The update also includes dependency bumps and new/updated tests for the affected features.

**Font Size Management and Settings Integration**
- Unified font size handling by moving all logic to `FontSizeService`, including support for a legacy key (`default_font_size`) and updating `SettingsService` to delegate font size persistence and loading to `FontSizeService`. This ensures backward compatibility and simplifies font size state management. [[1]](diffhunk://#diff-b0c00dcd7bc4aea7a0bcdb237174be7bb8981535ed26b607a246a1c62f78a5d6R12) [[2]](diffhunk://#diff-b0c00dcd7bc4aea7a0bcdb237174be7bb8981535ed26b607a246a1c62f78a5d6L30-R48) [[3]](diffhunk://#diff-d45d5c57d89eb43ba307f6733024bc154441b3477e881a6e3775b6ea596ad0ffL39-R43)
- Refactored `WebviewNotifier` to listen to font size changes directly from `settingsProvider`, removing redundant local state and ensuring the webview always reflects the latest setting. [[1]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L43) [[2]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L61-R72) [[3]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L74-L102) [[4]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L534-R539) [[5]](diffhunk://#diff-a4f28f57cc2d7a712e8bb21c0cd8adc3adb055cc686a7d38c0d1296246d3b472L560)

**User Experience Enhancements**
- Added a "Star on Github" `ActionChip` to the home screen, allowing users to easily access and star the app's source repository. Includes haptic feedback and error handling for failed launches. [[1]](diffhunk://#diff-efed4f50e946c6e317bcdc5e332d4d409ca2b838546bf60cfc7936b003c8413fR85-R99) [[2]](diffhunk://#diff-efed4f50e946c6e317bcdc5e332d4d409ca2b838546bf60cfc7936b003c8413fR259-R266)
- Updated imports and utility usage in the home screen to support the new GitHub star action.

**Testing Improvements**
- Added and updated tests to cover legacy font size key fallback, integration with settings, and the new GitHub star action. This ensures robust handling of edge cases and new features. [[1]](diffhunk://#diff-fec21a2ba84c663b795b5736fbdda24229d84397ec74b654442fb1095e0f440dR15-R22) [[2]](diffhunk://#diff-9cede733e2fe2b5d374811ebfb152c1af0815780ee4a884a1a0a30f4e9b88ef4R6-R8) [[3]](diffhunk://#diff-9cede733e2fe2b5d374811ebfb152c1af0815780ee4a884a1a0a30f4e9b88ef4R57-R84) [[4]](diffhunk://#diff-6072dd049e86d47b33d223fd67bc9e0b56a17ad4fb66d84e3dcedff50583060bL179-R179) [[5]](diffhunk://#diff-78ab9fe23addc893882a245a52cafd0eb5d56ce2ae6550f2b02f52041803544eL138-R138) [[6]](diffhunk://#diff-78ab9fe23addc893882a245a52cafd0eb5d56ce2ae6550f2b02f52041803544eR151-R159) [[7]](diffhunk://#diff-78ab9fe23addc893882a245a52cafd0eb5d56ce2ae6550f2b02f52041803544eL160-R169) [[8]](diffhunk://#diff-5dfa98f5522d129903f2bd109520ab39aa34914f1a8074950635bd939f990469R4) [[9]](diffhunk://#diff-5dfa98f5522d129903f2bd109520ab39aa34914f1a8074950635bd939f990469R62-R89)

**Dependency and Version Updates**
- Bumped the app version to `0.11.0+11` and updated dependencies for `webview_flutter_android` and `webview_flutter_wkwebview` for improved compatibility and stability. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L15-R16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Star on GitHub" button to Home for quick access to the app's source repository.

* **Refactor**
  * Improved font-size preference persistence with legacy-key fallback.
  * Webview now synchronizes font size directly from app settings.

* **Tests**
  * Added unit and widget tests covering font-size fallback, reset behavior, and the GitHub link.

* **Chores**
  * Bumped app version to 0.11.0 and updated webview dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->